### PR TITLE
Change time in painting when space width is determined.

### DIFF
--- a/pdt_tools.indentGuide/src/jp/sourceforge/pdt_tools/indentguide/IndentGuidePainter.java
+++ b/pdt_tools.indentGuide/src/jp/sourceforge/pdt_tools/indentguide/IndentGuidePainter.java
@@ -173,6 +173,7 @@ public class IndentGuidePainter implements IPainter, PaintListener {
 			gc.setForeground(Activator.getDefault().getColor());
 			gc.setLineStyle(lineStyle);
 			gc.setLineWidth(lineWidth);
+			spaceWidth = gc.getAdvanceWidth(' ');
 			if (fIsAdvancedGraphicsPresent) {
 				int alpha = gc.getAlpha();
 				gc.setAlpha(this.lineAlpha);
@@ -202,7 +203,6 @@ public class IndentGuidePainter implements IPainter, PaintListener {
 	 */
 	private void drawLineRange(GC gc, int startLine, int endLine, int x, int w) {
 		int tabs = fTextWidget.getTabs();
-		spaceWidth = gc.getAdvanceWidth(' ');
 
 		StyledTextContent content = fTextWidget.getContent();
 		for (int line = startLine; line <= endLine; line++) {


### PR DESCRIPTION
Some fonts cannot be correctly drawn or measured in SWT when advanced graphics mode is set on. Example of such font is https://github.com/belluzj/fantasque-sans. So this patch measures space width before advanced mode is turned on when alpha is set.

Before:
![before](https://cloud.githubusercontent.com/assets/708023/5888516/a016dc34-a412-11e4-865e-bd15d1b52b6a.png)

After:
![after](https://cloud.githubusercontent.com/assets/708023/5888517/a7ed6248-a412-11e4-9501-186356d3bcde.png)
